### PR TITLE
fix: Remove redundant browserslist

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,6 @@
 {
   "presets": [
     ["@shopify/babel-preset/web", {
-      "browsers": [
-        "last 3 versions"
-      ],
       "modules": false
     }]
   ],


### PR DESCRIPTION
Maybe I'm missing something but I don't know why there are two browserslists across `package.json` and `.babelrc`. To be sure, the [@shopify/babel-preset](https://www.npmjs.com/package/@shopify/babel-preset/v/23.5.0-common-beta.1) NPM package README recommends using solely `package.json`. So I've removed it from `.babelrc`.

**Test**
Using [shopify-packer](https://github.com/hayes0724/shopify-packer), the test script transpiles as expected according to different browserlist settings in `package.json`.

```js
// `src/scripts/layout/theme.js`
console.log(window.xyz ?? 1);

// `dist/assets/layout.theme.js` w/ "defaults"
!function(){var o;console.log(null!==(o=window.xyz)&&void 0!==o?o:1)}();

// `dist/assets/layout.theme.js` w/ "last 2 Chrome versions"
console.log(window.xyz??1);
```